### PR TITLE
Updating to INSTAGRAM_ prefix for multi-api development

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Instagram v1 API wrapper written in Elixir.
 
-Please note, this is very much a work in progress. 
+Please note, this is very much a work in progress.
 Feel free to contribute using pull requests.
 
 ## Example usage
@@ -23,7 +23,7 @@ To run it yourself, please run the following commands:
 * `npm install` (may not be needed, but if you see any node-esque "throw err;" messages, this is why)
 
 Before you can run it yourself, you'll have to configure three environment variables:
-They are `CLIENT_ID`, `CLIENT_SECRET`, and `CALLBACK_URL` (see `exstagram/lib/instagram.ex` for usage)
+They are `INSTAGRAM_CLIENT_ID`, `INSTAGRAM_CLIENT_SECRET`, and `INSTAGRAM_CALLBACK_URL` (see `exstagram/lib/instagram.ex` for usage)
 Finally, run:
 * `mix pheonix.server`
 

--- a/lib/instagram.ex
+++ b/lib/instagram.ex
@@ -7,9 +7,9 @@ defmodule Instagram do
     HTTPoison.start
     OAuth2.new([
       strategy: __MODULE__,
-      client_id: System.get_env("CLIENT_ID"),
-      client_secret: System.get_env("CLIENT_SECRET"),
-      redirect_uri: System.get_env("CALLBACK_URL"),
+      client_id: System.get_env("INSTAGRAM_CLIENT_ID"),
+      client_secret: System.get_env("INSTAGRAM_CLIENT_SECRET"),
+      redirect_uri: System.get_env("INSTAGRAM_CALLBACK_URL"),
       site: "https://api.instagram.com",
       authorize_url: "https://api.instagram.com/oauth/authorize/",
       token_url: "https://api.instagram.com/oauth/access_token"
@@ -36,7 +36,7 @@ defmodule Instagram do
     client
     |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
-  end 
+  end
 
   def user_recent_media(access_token) do
   	url = "https://api.instagram.com/v1/users/self/media/recent?access_token="
@@ -52,7 +52,7 @@ defmodule Instagram do
         IO.inspect reason
     end
   end
-  
+
   def start do
     auth_url = Instagram.authorize_url!
     response = HTTPoison.get! auth_url


### PR DESCRIPTION
I currently use multiple APIs for development, and I can't have an API using the global name scope in environmental variables. This updates it with a prefix of `INSTAGRAM_`.
